### PR TITLE
.dockerignore and removal of /www

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,4 +30,7 @@ coverage
 test-results/
 playwright-report/
 
-api/.env/
+# .dockerignore specific stuff
+.github/
+.git/
+Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,3 @@ coverage
 
 test-results/
 playwright-report/
-
-api/.env/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 # Install the (non-python) dependencies
 RUN apk add --no-cache npm python3-dev py3-pip libpq-dev build-base
-# Setup the user `npc` with BASH as the main shell
+# Setup the user `npc` for the server
 RUN adduser -D npc
 USER npc
 RUN mkdir /home/npc/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,22 @@
 FROM alpine:latest
+# Install the (non-python) dependencies
 RUN apk add --no-cache npm python3-dev py3-pip libpq-dev build-base
-WORKDIR /app
-COPY api/requirements.txt api/requirements.txt
+# Setup the user `npc` with BASH as the main shell
+RUN adduser -D npc
+USER npc
+RUN mkdir /home/npc/app
+WORKDIR /home/npc/app
+ENV PATH="${PATH}:/home/npc/.local/bin"
+# Install python backend dependencies
+COPY --chown=npc api/requirements.txt api/requirements.txt
 RUN pip3 install -r api/requirements.txt
-COPY package.json package-lock.json ./
+# Install frontend dependencies
+COPY --chown=npc package.json package-lock.json ./
 RUN npm install
-COPY . .
+# Copy the source over (subject to .dockerignore and api/.dockerignore)
+COPY --chown=npc . .
+# Build the frontend
 RUN npm run build
-RUN mv dist /www
-WORKDIR /app/api
+# Start the server
+WORKDIR /home/npc/app/api
 CMD ["/bin/sh", "-c", "python -m flask run --host=0.0.0.0 --port=$PORT"]

--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,176 @@
+# Created by https://www.toptal.com/developers/gitignore/api/python
+# Edit at https://www.toptal.com/developers/gitignore?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
+
+# End of https://www.toptal.com/developers/gitignore/api/python

--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -174,3 +174,4 @@ poetry.toml
 pyrightconfig.json
 
 # End of https://www.toptal.com/developers/gitignore/api/python
+.env

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -174,3 +174,4 @@ poetry.toml
 pyrightconfig.json
 
 # End of https://www.toptal.com/developers/gitignore/api/python
+.env

--- a/api/app.py
+++ b/api/app.py
@@ -4,12 +4,12 @@ from importlib import import_module
 from os import environ, listdir
 
 from models import db
-from models.task import Task
 
 running_as_dev = 'DEV' in environ
+static_folder = '../dist'
 
 # Create flask app instance
-app = flask.Flask(__name__, static_folder="/www", static_url_path="/")
+app = flask.Flask(__name__, static_folder=static_folder, static_url_path="/")
 
 # Work around deprecated "postgres://" dialect in the
 # https://stackoverflow.com/a/66794960

--- a/api/routes/index.py
+++ b/api/routes/index.py
@@ -1,6 +1,7 @@
-from app import app
+from app import app, static_folder
 import flask
+
 
 @app.route("/")
 def index():
-    return flask.send_file("/www/index.html")
+    return flask.send_file(f"{static_folder}/index.html")


### PR DESCRIPTION
This PR
- [x] Adds `npc` user in the  dockerfile to not run stuff as root
- [x] Removes `/www` directory and serves directly from `/dist` on the flask server (needed for the playright changes)
- [x] Adds `(api/).dockerignore` and some missing  `.gitignore` entries