### PR TITLE
Mobile improvements

### DIFF
--- a/src/components/session/CurrentSessionView.vue
+++ b/src/components/session/CurrentSessionView.vue
@@ -91,8 +91,7 @@ export default {
   <div class="w-100 h-100 card">
     <div class="card-header hstack">
       <span class="me-auto"
-        >Session (in progress, current time
-        {{ currentDate.toTimeString() }})</span
+        >Session (Time is {{ currentDate.toLocaleTimeString("en-GB") }})</span
       >
       <button type="button" class="btn btn-sm btn-warning me-1" @click="jump">
         Skip 15 minutes ahead

--- a/src/components/session/CurrentSessionView.vue
+++ b/src/components/session/CurrentSessionView.vue
@@ -105,7 +105,7 @@ export default {
         End session
       </button>
     </div>
-    <div class="card-body overflow-hidden">
+    <div class="card-body overflow-y-scroll overflow-x-visible">
       <!-- TODO: what should the key for the slot be? -->
       <TimelineElem
         v-for="slot in session?.slots"

--- a/src/components/session/CurrentSessionView.vue
+++ b/src/components/session/CurrentSessionView.vue
@@ -28,13 +28,10 @@ export default {
         if (this.session === undefined) {
           return "auto";
         }
-        const sessionStart = this.session.start.getTime();
-        const sessionEnd = this.session.end.getTime();
         const slotStart = start.getTime();
         const slotEnd = end.getTime();
 
-        const ratio = (slotEnd - slotStart) / (sessionEnd - sessionStart);
-        return `${100 * ratio}%`;
+        return `${Math.log2((slotEnd - slotStart) / 60000) * 2}em`;
       },
 
       calculateSlotCompleteness(start: Date, end: Date): number {

--- a/src/components/session/TimelineElem.vue
+++ b/src/components/session/TimelineElem.vue
@@ -49,7 +49,7 @@ export default {
       </div>
       <div class="me-auto w-100 h-100">
         <div class="card w-100 h-100">
-          <div class="card-body p-2 w-100 h-100 overflow-scroll">
+          <div class="card-body p-2 w-100 h-100 overflow-visible">
             <slot />
           </div>
         </div>

--- a/src/components/tasks/TaskListView.vue
+++ b/src/components/tasks/TaskListView.vue
@@ -77,7 +77,7 @@ export default {
         <NewTaskSetup @add="add" />
       </div>
     </div>
-    <div class="card-body tasks-overflow">
+    <div class="card-body overflow-y-scroll overflow-x-visible">
       <div v-for="task in sortedTaskList" :key="task.id" class="p-2">
         <TaskListItem
           :task="task"
@@ -88,18 +88,3 @@ export default {
     </div>
   </div>
 </template>
-
-<style scoped>
-.tasks-overflow {
-  overflow-y: scroll;
-}
-
-.tasks-overflow::-webkit-scrollbar {
-  display: none;
-}
-
-.tasks-overflow {
-  -ms-overflow-style: none;
-  scrollbar-width: none;
-}
-</style>


### PR DESCRIPTION
Rather than express the height of each slot as a percentage of the
window height, which leads to very squished ui on mobile, have it be a
constant amount of ems.

This makes the UI usable when a phone is in landscape mode.

The scaling is logorithmic to avoid short sessions being dwarfed by
longer work sessions. To avoid issues, we shouldn't schedule breaks or
sessions shorter than four minutes.