### PR TITLE
Bugfixes for tomorrow (today)

### DIFF
--- a/api/util/user_id.py
+++ b/api/util/user_id.py
@@ -1,5 +1,5 @@
 from uuid import UUID, uuid4
-from flask import request, abort
+from flask import request, abort, Response
 from app import running_as_dev
 
 # SameSite parameter for the SetCookie header. Should be strict if frontend and API run off one domain
@@ -27,6 +27,9 @@ def with_user_id(func):
 
         res = func(id)
         if set_cookie:
+            if isinstance(res, tuple):
+                res = Response(res[0], status=res[1])
+
             res.set_cookie(
                 _cookies_user_id_key, str(id), samesite=samesite, secure=True
             )

--- a/src/api/tasks.ts
+++ b/src/api/tasks.ts
@@ -8,7 +8,7 @@ export interface APITask {
   name: string;
   description: string | null;
   duration: number | null;
-  completed: boolean;
+  complete: boolean;
 }
 
 export class Task {
@@ -36,7 +36,7 @@ export class Task {
         apiTask.description === null ? undefined : apiTask.description,
       duration:
         apiTask.duration === null ? undefined : new Duration(apiTask.duration),
-      complete: apiTask.completed,
+      complete: apiTask.complete,
     });
   }
 }

--- a/src/components/tasks/NewTaskSetup.vue
+++ b/src/components/tasks/NewTaskSetup.vue
@@ -92,6 +92,10 @@ export default {
               theme="snow"
               toolbar="essential"
               content-type="html"
+              :modules="{
+                name: 'Magic URL plugin',
+                module: MagicUrl,
+              }"
             />
           </div>
         </div>


### PR DESCRIPTION
This fixes three things

- [x] Whenever a flask route returns a tuple, it is converted to the response object so that set_cookie() method does not fail
- [x] Fixed task API spelling mistake causing issues
- [X] MagicURL plugin is now installed in the NewTaskSetup SFC 