### PR TITLE
NewSessionSetup: slight UI adjustments

### DIFF
--- a/src/components/session/NewSessionSetup.vue
+++ b/src/components/session/NewSessionSetup.vue
@@ -47,7 +47,7 @@ export default {
 
 <template>
   <div class="w-100 h-100 card">
-    <div class="m-auto w-50 h-auto card">
+    <div class="m-auto h-auto card" style="min-width: 75%;">
       <div class="card-header">Create a new session</div>
       <div class="card-body">
         <div class="mb-3">
@@ -66,19 +66,19 @@ export default {
         </div>
         <div class="hstack">
           <button
+            v-if="savedSession"
             type="button"
-            class="btn btn-sm btn-outline-success ms-1"
+            class="btn btn-sm btn-info me-auto"
+            @click="restoreSession"
+          >
+            Restore previous session
+          </button>
+          <button
+            type="button"
+            class="btn btn-sm btn-success"
             @click="createSession"
           >
             Create session
-          </button>
-          <button
-            v-if="savedSession"
-            type="button"
-            class="btn btn-sm btn-success ms-1"
-            @click="restoreSession"
-          >
-            Restore session
           </button>
         </div>
       </div>

--- a/src/components/session/NewSessionSetup.vue
+++ b/src/components/session/NewSessionSetup.vue
@@ -47,7 +47,7 @@ export default {
 
 <template>
   <div class="w-100 h-100 card">
-    <div class="m-auto h-auto card" style="min-width: 75%;">
+    <div class="m-auto h-auto card" style="min-width: 75%">
       <div class="card-header">Create a new session</div>
       <div class="card-body">
         <div class="mb-3">


### PR DESCRIPTION
It felt weird to me that restoring previous session was a highlighted option. I made it a bit more even
![image](https://github.com/DRP-4/DRP-4/assets/66870461/4903f29b-c15a-4be2-a07b-fd4dd4b554ab)
This also partially fixes appearance on mobile  