### PR TITLE
everywhere: Rework time jumps

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1,5 +1,6 @@
 import flask
 from flask_cors import CORS
+from flask_socketio import SocketIO
 from importlib import import_module
 from os import environ, listdir
 
@@ -26,7 +27,20 @@ app.config["SQLALCHEMY_DATABASE_URI"] = environ["DATABASE_URL"].replace(
 db.init_app(app)
 
 # This let's all origins access the API, which is probably fine for us.
-CORS(app)
+cors = CORS()
+cors.init_app(app)
+
+# Initialize SocketIO
+socketio = SocketIO()
+if running_as_dev:
+    socketio.init_app(app, cors_allowed_origins="*")
+else:
+    socketio.init_app(app)
+
+
+@socketio.on("connect")
+def socketio_connect():
+    pass
 
 
 # Upgrade all HTTP requests to HTTPS

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -4,3 +4,5 @@ Flask-SQLAlchemy==3.0.3
 SQLAlchemy-Utils==0.41.1
 Flask-Cors==3.0.10
 psycopg2==2.9.6
+Flask-SocketIO==5.3.4
+simple-websocket==0.10.1

--- a/api/routes/debug.py
+++ b/api/routes/debug.py
@@ -1,14 +1,24 @@
-from app import app, running_as_dev
+from app import app, running_as_dev, socketio
 from flask import request, abort
+from util.response import json_response
+from os import environ
 import util.now
+
+allow_jumps = running_as_dev or "ALLOW_JUMPS" in environ
+
+
+@app.route("/api/debug/jump-seconds", methods=["GET"])
+def get_delta():
+    return json_response({"seconds": util.now.delta})
 
 
 @app.route("/api/debug/jump-seconds", methods=["POST"])
 def jump():
     body = request.get_json()
-    if not running_as_dev:
+    if not allow_jumps:
         return "Forbidden", 403
     elif "seconds" not in body or not isinstance(body["seconds"], int):
         return "Bad Request", 400
     util.now.delta = body["seconds"]
+    socketio.emit("jump-seconds", {"seconds": util.now.delta})
     return "", 204

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "parse-duration": "^1.1.0",
         "pinia": "^2.0.36",
         "quill-magic-url": "^4.2.0",
+        "socket.io-client": "^4.6.2",
         "vue": "^3.3.2",
         "vue-router": "^4.2.0"
       },
@@ -564,6 +565,11 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.3.0.tgz",
       "integrity": "sha512-IthPJsJR85GhOkp3Hvp8zFOPK5ynKn6STyHa/WZpioK7E1aYDiBzpqQPrngc14DszIUkIrdd3k9Iu0XSzlP/1w==",
       "dev": true
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
@@ -1639,7 +1645,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1774,6 +1779,46 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.4.0.tgz",
+      "integrity": "sha512-GyKPDyoEha+XZ7iEqam49vz6auPnNJ9ZBfy89f+rMMas8AuiMWOZ9PVzu8xb9ZC6rafUqiGHSCfu22ih66E+1g==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.0.3",
+        "ws": "~8.11.0",
+        "xmlhttprequest-ssl": "~2.0.0"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ws": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.7.tgz",
+      "integrity": "sha512-P+jDFbvK6lE3n1OL+q9KuzdOFWkkZ/cMV9gol/SbVfpyqfvrfrFTOFJ6fQm2VC3PZHlU3QPhVwmbsCnauHF2MQ==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/entities": {
@@ -3326,8 +3371,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/muggle-string": {
       "version": "0.2.2",
@@ -4127,14 +4171,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/quill-markdown-shortcuts": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/quill-markdown-shortcuts/-/quill-markdown-shortcuts-0.0.10.tgz",
-      "integrity": "sha512-2FFFqqo65JgDgAGSer7cFQTCeiSjJF4N8lRGXGv/xjppCxSwj42OnNdGPZ/zeeCxdUY/j1LW4AiSvPQaTIkY2A==",
-      "dependencies": {
-        "quill": "^1.3.1"
-      }
-    },
     "node_modules/quill/node_modules/fast-diff": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
@@ -4451,6 +4487,32 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.6.2.tgz",
+      "integrity": "sha512-OwWrMbbA8wSqhBAR0yoPK6EdQLERQAYjXb3A0zLpgxfM1ZGLKoxHx8gVmCHA6pcclRX5oA/zvQf7bghAS11jRA==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.4.0",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/source-map-js": {
@@ -5298,6 +5360,14 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/yallist": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "parse-duration": "^1.1.0",
     "pinia": "^2.0.36",
     "quill-magic-url": "^4.2.0",
+    "socket.io-client": "^4.6.2",
     "vue": "^3.3.2",
     "vue-router": "^4.2.0"
   },

--- a/src/api/debug.ts
+++ b/src/api/debug.ts
@@ -1,12 +1,9 @@
-import { post } from "@/api";
-import { store } from "@/stores/time_jump";
+import { get, post } from "@/api";
 
-export async function jumpSeconds(seconds: number) {
-  store.jump(seconds);
-  return await post("debug/jump-seconds", { seconds: store.deltaInSeconds });
+export async function getJumpCounter(): Promise<number> {
+  return (await get("debug/jump-seconds")).seconds;
 }
 
-export async function resetJumpCounter() {
-  store.jump(0);
-  return await post("debug/jump-seconds", { seconds: 0 });
+export async function setJumpCounter(seconds: number) {
+  return await post("debug/jump-seconds", { seconds: seconds });
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,6 +1,10 @@
+import { io } from "socket.io-client";
+
 const API_BASE = import.meta.env.DEV
   ? "http://127.0.0.1:5000"
   : "https://drp-04.herokuapp.com/";
+
+export const socket = io(API_BASE);
 
 function newAPIRequest(route: String): Request {
   // Include credentials for the cookie to be included

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import { createPinia } from "pinia";
 
 import App from "./App.vue";
 import router from "./router";
+import { store as timeJumpStore } from "./stores/time_jump";
 
 const app = createApp(App);
 
@@ -14,3 +15,7 @@ app.use(createPinia());
 app.use(router);
 
 app.mount("#app");
+
+(async () => {
+  await timeJumpStore.fetchFromDB();
+})();

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -24,6 +24,10 @@ const router = createRouter({
       path: "/demos/session_done",
       component: () => import("../views/SessionDoneDemo.vue"),
     },
+    {
+      path: "/debug/time",
+      component: () => import("../views/TimeControl.vue"),
+    },
   ],
 });
 

--- a/src/stores/time_jump.ts
+++ b/src/stores/time_jump.ts
@@ -1,13 +1,37 @@
 import { reactive } from "vue";
+import { setJumpCounter, getJumpCounter } from "@/api/debug";
+import { socket } from "@/api";
 
 export const store = reactive({
   deltaInSeconds: 0,
 
-  jump(by: number) {
-    this.deltaInSeconds += by;
+  async fetchFromDB() {
+    this.deltaInSeconds = await getJumpCounter();
   },
 
-  reset() {
-    this.deltaInSeconds = 0;
+  async jump(by: number) {
+    this.deltaInSeconds += by;
+    await setJumpCounter(this.deltaInSeconds);
   },
+
+  async reset() {
+    this.deltaInSeconds = 0;
+    await setJumpCounter(0);
+  },
+
+  dateWithDebugOffset(): Date {
+    const thisInstant = new Date();
+    const thisInstantUnix = thisInstant.getTime();
+    const newInstantUnix = thisInstantUnix + this.deltaInSeconds * 1000;
+    const newInstant = new Date(newInstantUnix);
+    return newInstant;
+  },
+});
+
+socket.on("jump-seconds", (data) => {
+  const newDelta = data.seconds;
+  // If statement is needed to not trigger unnecessary reactive updates
+  if (store.deltaInSeconds != newDelta) {
+    store.deltaInSeconds = newDelta;
+  }
 });

--- a/src/views/TimeControl.vue
+++ b/src/views/TimeControl.vue
@@ -1,0 +1,60 @@
+<script lang="ts">
+import { store as timeJumpStore } from "@/stores/time_jump";
+
+export default {
+  data() {
+    return {
+      realDate: new Date(),
+      currentDate: timeJumpStore.dateWithDebugOffset(),
+      interval: undefined as ReturnType<typeof setInterval> | undefined,
+      buttonDeltas: [5, 10, 15, 20, 30, 60, 120],
+      timeJumpStore,
+    };
+  },
+
+  async mounted() {
+    this.interval = setInterval(() => {
+      this.realDate = new Date();
+      this.currentDate = timeJumpStore.dateWithDebugOffset();
+    });
+  },
+
+  async unmounted() {
+    clearInterval(this.interval);
+  },
+};
+</script>
+
+<template>
+  <div class="vh-100 vw-100 p-4 d-flex">
+    <div class="card m-auto h-auto">
+      <div class="card-header hstack">
+        <span class="me-auto"
+          >Real time: {{ realDate.toTimeString().slice(0, 8) }}</span
+        >
+        <span>Mock time: {{ currentDate.toTimeString().slice(0, 8) }}</span>
+        <span class="ms-auto"
+          >Delta: {{ Math.floor(timeJumpStore.deltaInSeconds / 60) }} mins</span
+        >
+      </div>
+      <div class="card-body">
+        <div class="hstack">
+          <button
+            class="btn btn-sm btn-danger mx-1"
+            @click="timeJumpStore.reset()"
+          >
+            Reset counter
+          </button>
+          <button
+            v-for="delta in buttonDeltas"
+            :key="delta"
+            class="btn btn-sm btn-warning mx-1"
+            @click="timeJumpStore.jump(delta * 60)"
+          >
+            + {{ delta }} min
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
Fixes #73

Does the following
- [x] Preserves time jump value across page refreshes (does not do that in the DB yet, is that something we want to potentially do?)
- [X] Adds endpoint for the frontend to retrieve current time jump value 
- [x] Removes the jump by 15 minutes button and introduces a separate time jump debug screen at `/debug/time`
![image](https://github.com/DRP-4/DRP-4/assets/66870461/bf1febd7-788c-4258-b866-455795657ef6)
- [x] Adds infrastructure for the websockets based on Socket.io library (it handles many things for us including HTTP polling fallback, automatic reconnects, but most importantly it **much more straightforward to send messages from normal flask routes - we do not have to bother with off-loading work to a background thread ourselves** )
- [x] Uses the library to propogate time jump updates to all clients
- [x] Adds `ALLOW_JUMPS` environment variable meant to be a replacement for `DEV` on heroku